### PR TITLE
Fix gradle build cfg for idea

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 idea {
     module {
         testOutputDir = file('output_tests')
-        inheritOutputDirs = false
+        inheritOutputDirs = true
         downloadJavadoc = true
         downloadSources = true
     }


### PR DESCRIPTION
Fixed gradle build cfg to use inheritance for modules instead of a default path which doesnt work for our setup