### PR TITLE
Allow Cubic Chunks to overrule height limits

### DIFF
--- a/src/main/java/icbm/classic/content/blast/threaded/BlastAntimatter.java
+++ b/src/main/java/icbm/classic/content/blast/threaded/BlastAntimatter.java
@@ -98,7 +98,14 @@ public class BlastAntimatter extends BlastThreaded
 
     protected boolean isInsideMap(int y)
     {
-        return y >= 0 && y < 256;
+        if (Loader.isModInstalled("CubicChunks")
+        {
+            return true;
+        }
+        else
+        {
+            return y >= 0 && y < 256;
+        }
     }
 
     protected boolean shouldEditPos(int x, int y, int z)


### PR DESCRIPTION
Should (I'm garbage at coding and very rusty at java) remove height limits for all worlds when Cubic Chunks is enabled. Please prove me wrong.