### PR TITLE
Feature/chem improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ ops.json
 whitelist.json
 
 output_tests/
+world/
+server.properties
+config/
+eula.txt
+usercache.json
+usernamecache.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 !*.*
 /bin
 /run
+/run_server
 /out
 
 *.classpath
@@ -38,9 +39,3 @@ ops.json
 whitelist.json
 
 output_tests/
-world/
-server.properties
-config/
-eula.txt
-usercache.json
-usernamecache.json

--- a/src/main/java/icbm/classic/CommonProxy.java
+++ b/src/main/java/icbm/classic/CommonProxy.java
@@ -1,5 +1,6 @@
 package icbm.classic;
 
+import icbm.classic.lib.network.packet.PacketSpawnAirParticle;
 import icbm.classic.prefab.tile.IGuiTile;
 import icbm.classic.content.entity.missile.EntityMissile;
 import icbm.classic.lib.transform.vector.Pos;
@@ -139,9 +140,9 @@ public class CommonProxy implements IGuiHandler
 
     }
 
-    public void spawnAirParticle(World world, Pos position, double v, double v1, double v2, float red, float green, float blue, float scale, int age)
+    public void spawnAirParticle(World world, Pos position, double v, double v1, double v2, float red, float green, float blue, float scale, int ticksToLive)
     {
-
+        PacketSpawnAirParticle.sendToAllClients(world, position, v, v1, v2, red, green, blue, scale, ticksToLive);
     }
 
     public void spawnMissileSmoke(EntityMissile missile)

--- a/src/main/java/icbm/classic/lib/network/netty/PacketEncoderDecoderHandler.java
+++ b/src/main/java/icbm/classic/lib/network/netty/PacketEncoderDecoderHandler.java
@@ -3,6 +3,7 @@ package icbm.classic.lib.network.netty;
 import icbm.classic.lib.network.IPacket;
 import icbm.classic.lib.network.packet.PacketPlayerItem;
 import icbm.classic.lib.network.packet.PacketRedmatterSizeSync;
+import icbm.classic.lib.network.packet.PacketSpawnAirParticle;
 import icbm.classic.lib.network.packet.PacketTile;
 import icbm.classic.ICBMClassic;
 import io.netty.buffer.ByteBuf;
@@ -24,6 +25,7 @@ public class PacketEncoderDecoderHandler extends FMLIndexedMessageToMessageCodec
         addPacket(PacketTile.class);
         addPacket(PacketPlayerItem.class);
         addPacket(PacketRedmatterSizeSync.class);
+        addPacket(PacketSpawnAirParticle.class);
     }
 
     public void addPacket(Class<? extends IPacket> clazz)

--- a/src/main/java/icbm/classic/lib/network/packet/PacketSpawnAirParticle.java
+++ b/src/main/java/icbm/classic/lib/network/packet/PacketSpawnAirParticle.java
@@ -23,21 +23,30 @@ import java.util.List;
 
 public class PacketSpawnAirParticle implements IPacket<PacketSpawnAirParticle>
 {
-    /** Size of the blast */
-    public float size;
-    /** ID of the entity controller of the blast */
-    public int entityID;
+    /*
+    Id of the dimension that this particle should be placed in.
+     */
     private int dimId;
+
+    // x y and z positions
     private double posX;
     private double posY;
     private double posZ;
+
+    // x y and z velocities
     private double v;
     private double v1;
     private double v2;
+
+    // red green and blue color values
     private float red;
     private float green;
     private float blue;
+
+    // size scale
     private float scale;
+
+    // how long this particle will live for
     private int ticksToLive;
 
     public PacketSpawnAirParticle()
@@ -48,7 +57,6 @@ public class PacketSpawnAirParticle implements IPacket<PacketSpawnAirParticle>
     public PacketSpawnAirParticle(int dimId, double posX, double posY, double posZ, double v, double v1, double v2,
                                   float red, float green, float blue, float scale, int ticksToLive)
     {
-
         this.dimId = dimId;
         this.posX = posX;
         this.posY = posY;
@@ -66,8 +74,6 @@ public class PacketSpawnAirParticle implements IPacket<PacketSpawnAirParticle>
     @Override
     public void encodeInto(ChannelHandlerContext ctx, ByteBuf buffer)
     {
-        /*buffer.writeFloat(size);
-        ByteBufUtils.writeVarInt(buffer, entityID, 5);*/
         buffer.writeInt(dimId);
         buffer.writeDouble(posX);
         buffer.writeDouble(posY);
@@ -85,20 +91,18 @@ public class PacketSpawnAirParticle implements IPacket<PacketSpawnAirParticle>
     @Override
     public void decodeInto(ChannelHandlerContext ctx, ByteBuf buffer)
     {
-       /* size = buffer.readFloat();
-        entityID = ByteBufUtils.readVarInt(buffer, 5);*/
-        dimId=buffer.readInt();
-        posX=buffer.readDouble();
-        posY=buffer.readDouble();
-        posZ=buffer.readDouble();
-        v=buffer.readDouble();
-        v1=buffer.readDouble();
-        v2=buffer.readDouble();
-        red=buffer.readFloat();
-        green=buffer.readFloat();
-        blue=buffer.readFloat();
-        scale=buffer.readFloat();
-        ticksToLive=buffer.readInt();
+        dimId = buffer.readInt();
+        posX = buffer.readDouble();
+        posY = buffer.readDouble();
+        posZ = buffer.readDouble();
+        v = buffer.readDouble();
+        v1 = buffer.readDouble();
+        v2 = buffer.readDouble();
+        red = buffer.readFloat();
+        green = buffer.readFloat();
+        blue = buffer.readFloat();
+        scale = buffer.readFloat();
+        ticksToLive = buffer.readInt();
     }
 
     @Override
@@ -107,21 +111,15 @@ public class PacketSpawnAirParticle implements IPacket<PacketSpawnAirParticle>
     {
         if (Minecraft.getMinecraft().world != null && player.world.provider.getDimension() == dimId)
         {
-            /*final Entity entity = Minecraft.getMinecraft().world.getEntityByID(entityID);
-            if (entity instanceof EntityExplosion && ((EntityExplosion) entity).getBlast() instanceof BlastRedmatter)
-            {
-                ((BlastRedmatter) ((EntityExplosion) entity).getBlast()).size = size;
-            }*/
-
-            ICBMClassic.proxy.spawnAirParticle(player.world, new Pos(posX,posY,posZ), v, v1, v2, red, green ,blue, scale, ticksToLive );
+            ICBMClassic.proxy.spawnAirParticle(player.world, new Pos(posX, posY, posZ), v, v1, v2, red, green, blue, scale, ticksToLive);
         }
     }
 
     public static void sendToAllClients(World world, Pos position, double v, double v1, double v2, float red, float green, float blue, float scale, int ticksToLive)
     {
         final int dimid = world.provider.getDimension();
-        final PacketSpawnAirParticle packet = new PacketSpawnAirParticle(dimid, position.x(), position.y(), position.z(), v, v1, v2, red, green ,blue, scale, ticksToLive);
-        final NetworkRegistry.TargetPoint point = new NetworkRegistry.TargetPoint(dimid, position.x(), position.y(), position.z(),256);
+        final PacketSpawnAirParticle packet = new PacketSpawnAirParticle(dimid, position.x(), position.y(), position.z(), v, v1, v2, red, green, blue, scale, ticksToLive);
+        final NetworkRegistry.TargetPoint point = new NetworkRegistry.TargetPoint(dimid, position.x(), position.y(), position.z(), 256);
         ICBMClassic.packetHandler.sendToAllAround(packet, point);
     }
 }

--- a/src/main/java/icbm/classic/lib/network/packet/PacketSpawnAirParticle.java
+++ b/src/main/java/icbm/classic/lib/network/packet/PacketSpawnAirParticle.java
@@ -1,0 +1,127 @@
+package icbm.classic.lib.network.packet;
+
+import icbm.classic.ICBMClassic;
+import icbm.classic.content.blast.BlastRedmatter;
+import icbm.classic.content.entity.EntityExplosion;
+import icbm.classic.lib.network.IPacket;
+import icbm.classic.lib.transform.vector.Pos;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PacketSpawnAirParticle implements IPacket<PacketSpawnAirParticle>
+{
+    /** Size of the blast */
+    public float size;
+    /** ID of the entity controller of the blast */
+    public int entityID;
+    private int dimId;
+    private double posX;
+    private double posY;
+    private double posZ;
+    private double v;
+    private double v1;
+    private double v2;
+    private float red;
+    private float green;
+    private float blue;
+    private float scale;
+    private int ticksToLive;
+
+    public PacketSpawnAirParticle()
+    {
+        //Needed for forge to construct the packet
+    }
+
+    public PacketSpawnAirParticle(int dimId, double posX, double posY, double posZ, double v, double v1, double v2,
+                                  float red, float green, float blue, float scale, int ticksToLive)
+    {
+
+        this.dimId = dimId;
+        this.posX = posX;
+        this.posY = posY;
+        this.posZ = posZ;
+        this.v = v;
+        this.v1 = v1;
+        this.v2 = v2;
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.scale = scale;
+        this.ticksToLive = ticksToLive;
+    }
+
+    @Override
+    public void encodeInto(ChannelHandlerContext ctx, ByteBuf buffer)
+    {
+        /*buffer.writeFloat(size);
+        ByteBufUtils.writeVarInt(buffer, entityID, 5);*/
+        buffer.writeInt(dimId);
+        buffer.writeDouble(posX);
+        buffer.writeDouble(posY);
+        buffer.writeDouble(posZ);
+        buffer.writeDouble(v);
+        buffer.writeDouble(v1);
+        buffer.writeDouble(v2);
+        buffer.writeFloat(red);
+        buffer.writeFloat(green);
+        buffer.writeFloat(blue);
+        buffer.writeFloat(scale);
+        buffer.writeInt(ticksToLive);
+    }
+
+    @Override
+    public void decodeInto(ChannelHandlerContext ctx, ByteBuf buffer)
+    {
+       /* size = buffer.readFloat();
+        entityID = ByteBufUtils.readVarInt(buffer, 5);*/
+        dimId=buffer.readInt();
+        posX=buffer.readDouble();
+        posY=buffer.readDouble();
+        posZ=buffer.readDouble();
+        v=buffer.readDouble();
+        v1=buffer.readDouble();
+        v2=buffer.readDouble();
+        red=buffer.readFloat();
+        green=buffer.readFloat();
+        blue=buffer.readFloat();
+        scale=buffer.readFloat();
+        ticksToLive=buffer.readInt();
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void handleClientSide(EntityPlayer player)
+    {
+        if (Minecraft.getMinecraft().world != null && player.world.provider.getDimension() == dimId)
+        {
+            /*final Entity entity = Minecraft.getMinecraft().world.getEntityByID(entityID);
+            if (entity instanceof EntityExplosion && ((EntityExplosion) entity).getBlast() instanceof BlastRedmatter)
+            {
+                ((BlastRedmatter) ((EntityExplosion) entity).getBlast()).size = size;
+            }*/
+
+            ICBMClassic.proxy.spawnAirParticle(player.world, new Pos(posX,posY,posZ), v, v1, v2, red, green ,blue, scale, ticksToLive );
+        }
+    }
+
+    public static void sendToAllClients(World world, Pos position, double v, double v1, double v2, float red, float green, float blue, float scale, int ticksToLive)
+    {
+        final int dimid = world.provider.getDimension();
+        final PacketSpawnAirParticle packet = new PacketSpawnAirParticle(dimid, position.x(), position.y(), position.z(), v, v1, v2, red, green ,blue, scale, ticksToLive);
+        final NetworkRegistry.TargetPoint point = new NetworkRegistry.TargetPoint(dimid, position.x(), position.y(), position.z(),256);
+        ICBMClassic.packetHandler.sendToAllAround(packet, point);
+    }
+}


### PR DESCRIPTION
Fixed particles not being displayed clientside in a Client-Server environment, since the server calls the spawn air particle method in the commonproxy, but since thats empty it didnt do anything. Related tickets: #362, #358

Improved the gaspathfinding, so gas is blocked by solid blocks and by full bounding boxes with respect to gas movement direction.
E.g. gas cannot move through a glasspane (assuming it only touches a block on the left and right) from the front or back, but it can from the top or bottom.
![image](https://user-images.githubusercontent.com/5289076/129143918-05a74b33-ed37-46ff-8ad5-c943ff3d2f26.png)

The gas is blocked by all blocks in the green wool area, but passes through the fence and also through the anvil in the red area.
The reason the anvil orientation matters is because the bounding box is a full square when looking at it from the front (1x1m),
but when looking at it from the side, it is not.
This is a much better behaviour than before, but can be further improved by making the iron bars pass-through.
Additionally the flow speed needs to be adjusted, but this is a minor thing.