### PR TITLE
Fixed missiles not showing up on radar

### DIFF
--- a/src/main/java/icbm/classic/content/entity/missile/EntityMissile.java
+++ b/src/main/java/icbm/classic/content/entity/missile/EntityMissile.java
@@ -158,7 +158,7 @@ public class EntityMissile extends EntityProjectile implements IEntityAdditional
     @Override
     public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
-        return capability == CapabilityEMP.EMP || super.hasCapability(capability, facing);
+        return capability == CapabilityEMP.EMP || capability == ICBMClassicAPI.MISSILE_CAPABILITY || super.hasCapability(capability, facing);
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
This fixes #344 and part of #369

Missiles did not have the missile capability so they did not show up on
the radar.