### PR TITLE
Simplify explosion iteration count calculation

### DIFF
--- a/src/main/java/icbm/classic/content/blast/thread/ThreadLargeExplosion.java
+++ b/src/main/java/icbm/classic/content/blast/thread/ThreadLargeExplosion.java
@@ -41,7 +41,7 @@ public class ThreadLargeExplosion extends ThreadExplosion
         long time = System.nanoTime();
 
         //How many steps to go per rotation
-        final int steps = (int) Math.ceil(Math.PI / Math.atan(1.0D / this.radius));
+        final int steps = (int) Math.ceil(Math.PI * this.radius);
 
         double x;
         double y;

--- a/src/main/java/icbm/classic/content/blast/threaded/BlastNuclear.java
+++ b/src/main/java/icbm/classic/content/blast/threaded/BlastNuclear.java
@@ -54,7 +54,7 @@ public class BlastNuclear extends BlastThreaded
     public boolean doRun(int loops, Consumer<BlockPos> edits)
     {
         //How many steps to go per rotation
-        final int steps = (int) Math.ceil(Math.PI / Math.atan(1.0D / this.getBlastRadius()));
+        final int steps = (int) Math.ceil(Math.PI * this.getBlastRadius());
 
         double x;
         double y;


### PR DESCRIPTION
Simplifies the nuclear/thermobaric explosion iteration count calculation. The following graph demonstrates the new equation is functionally equivalent: https://www.desmos.com/calculator/kdshnrxxpk