### PR TITLE
Fix #447

### DIFF
--- a/src/main/java/icbm/classic/lib/projectile/EntityProjectile.java
+++ b/src/main/java/icbm/classic/lib/projectile/EntityProjectile.java
@@ -280,7 +280,13 @@ public abstract class EntityProjectile<PROJECTILE extends EntityProjectile<PROJE
             if (rayHit != null && rayHit.typeOfHit != RayTraceResult.Type.MISS && !ignoreImpact(rayHit)) {
                 //Handle entity hit
                 if (rayHit.typeOfHit == RayTraceResult.Type.ENTITY) {
-                    handleEntityCollision(rayHit, rayHit.entityHit);
+                    //rayHit.hitVec == rayHit.entityHit.pos, So, hitbox points are calculated to prevent the entity from disappearing.
+                    RayTraceResult hitPoint = rayHit.entityHit.getEntityBoundingBox().calculateIntercept(
+                        new Vec3d(posX, posY, posZ),
+                        new Vec3d(rayHit.entityHit.posX, rayHit.entityHit.posY, rayHit.entityHit.posZ)
+                    );
+
+                    handleEntityCollision(hitPoint, rayHit.entityHit);
                 } else //Handle block hit
                 {
                     handleBlockCollision(rayHit);
@@ -470,7 +476,6 @@ public abstract class EntityProjectile<PROJECTILE extends EntityProjectile<PROJE
                 && entityHit instanceof EntityLivingBase) {
                 applyKnockBack(entityHit);
             }
-            hit.hitVec = hit.hitVec.add(new Vec3d(0, 0.5, 0)); //Add some offset to prevent the entity from disappearing
             onImpact(hit);
             // TODO add deflection for some projectiles, so when impact entities the projectile might redirect rather than vanish
         }

--- a/src/main/java/icbm/classic/lib/projectile/EntityProjectile.java
+++ b/src/main/java/icbm/classic/lib/projectile/EntityProjectile.java
@@ -470,6 +470,7 @@ public abstract class EntityProjectile<PROJECTILE extends EntityProjectile<PROJE
                 && entityHit instanceof EntityLivingBase) {
                 applyKnockBack(entityHit);
             }
+            hit.hitVec = hit.hitVec.add(new Vec3d(0, 0.5, 0)); //Add some offset to prevent the entity from disappearing
             onImpact(hit);
             // TODO add deflection for some projectiles, so when impact entities the projectile might redirect rather than vanish
         }


### PR DESCRIPTION
Fix #447

Added an offset to the explosion coordinates of where the entity was hit by the missile.

It may fly away, but the coordinates won't be NaN.